### PR TITLE
Provide packages `boost@1.69` and `boost-python3@1.69`

### DIFF
--- a/boost-python3@1.69.rb
+++ b/boost-python3@1.69.rb
@@ -1,0 +1,102 @@
+class BoostPython3AT169 < Formula
+  desc "C++ library for C++/Python3 interoperability"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
+  sha256 "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
+  head "https://github.com/boostorg/boost.git"
+
+  bottle do
+    cellar :any
+    rebuild 1
+    sha256 "b9e02f1dd677ceceda95c9aa3575349bd3018660d4e886be62b7ed6a5d7477b5" => :mojave
+    sha256 "791e187908f45d3a1353e9f69838c8a5d66ade9e4d410d2f6f6768d8d20d48e3" => :high_sierra
+    sha256 "ee30161bc4d164d6f92b2150a37ef1964a9c2cd24510147bcfd48103e7903887" => :sierra
+  end
+
+  depends_on "boost"
+  depends_on "python"
+
+  resource "numpy" do
+    url "https://files.pythonhosted.org/packages/2d/80/1809de155bad674b494248bcfca0e49eb4c5d8bee58f26fe7a0dd45029e2/numpy-1.15.4.zip"
+    sha256 "3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7"
+  end
+
+  def install
+    # "layout" should be synchronized with boost
+    args = ["--prefix=#{prefix}",
+            "--libdir=#{lib}",
+            "-d2",
+            "-j#{ENV.make_jobs}",
+            "--layout=tagged-1.66",
+            "--user-config=user-config.jam",
+            "threading=multi,single",
+            "link=shared,static"]
+
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    # disable python detection in bootstrap.sh; it guesses the wrong include
+    # directory for Python 3 headers, so we configure python manually in
+    # user-config.jam below.
+    inreplace "bootstrap.sh", "using python", "#using python"
+
+    pyver = Language::Python.major_minor_version "python3"
+    py_prefix = Formula["python3"].opt_frameworks/"Python.framework/Versions/#{pyver}"
+
+    numpy_site_packages = buildpath/"homebrew-numpy/lib/python#{pyver}/site-packages"
+    numpy_site_packages.mkpath
+    ENV["PYTHONPATH"] = numpy_site_packages
+    resource("numpy").stage do
+      system "python3", *Language::Python.setup_install_args(buildpath/"homebrew-numpy")
+    end
+
+    # Force boost to compile with the desired compiler
+    (buildpath/"user-config.jam").write <<~EOS
+      using darwin : : #{ENV.cxx} ;
+      using python : #{pyver}
+                   : python3
+                   : #{py_prefix}/include/python#{pyver}m
+                   : #{py_prefix}/lib ;
+    EOS
+
+    system "./bootstrap.sh", "--prefix=#{prefix}", "--libdir=#{lib}",
+                             "--with-libraries=python", "--with-python=python3",
+                             "--with-python-root=#{py_prefix}"
+
+    system "./b2", "--build-dir=build-python3", "--stagedir=stage-python3",
+                   "python=#{pyver}", *args
+
+    lib.install Dir["stage-python3/lib/*py*"]
+    doc.install Dir["libs/python/doc/*"]
+  end
+
+  test do
+    (testpath/"hello.cpp").write <<~EOS
+      #include <boost/python.hpp>
+      char const* greet() {
+        return "Hello, world!";
+      }
+      BOOST_PYTHON_MODULE(hello)
+      {
+        boost::python::def("greet", greet);
+      }
+    EOS
+
+    pyincludes = Utils.popen_read("python3-config --includes").chomp.split(" ")
+    pylib = Utils.popen_read("python3-config --ldflags").chomp.split(" ")
+    pyver = Language::Python.major_minor_version("python3").to_s.delete(".")
+
+    system ENV.cxx, "-shared", "hello.cpp", "-L#{lib}", "-lboost_python#{pyver}", "-o",
+           "hello.so", *pyincludes, *pylib
+
+    output = <<~EOS
+      import hello
+      print(hello.greet())
+    EOS
+    assert_match "Hello, world!", pipe_output("python3", output, 0)
+  end
+end

--- a/boost-python3@1.69.rb
+++ b/boost-python3@1.69.rb
@@ -7,13 +7,11 @@ class BoostPython3AT169 < Formula
 
   bottle do
     cellar :any
-    rebuild 1
-    sha256 "b9e02f1dd677ceceda95c9aa3575349bd3018660d4e886be62b7ed6a5d7477b5" => :mojave
-    sha256 "791e187908f45d3a1353e9f69838c8a5d66ade9e4d410d2f6f6768d8d20d48e3" => :high_sierra
-    sha256 "ee30161bc4d164d6f92b2150a37ef1964a9c2cd24510147bcfd48103e7903887" => :sierra
+    root_url "https://github.com/fiedl/homebrew-icecube/releases/download/boost-1.69.0_2/"
+    sha256 "7e07eb4a74d834b82976f5e6335779c98d6c57bf62eb6b34f747d43b258af254" => :mojave
   end
 
-  depends_on "boost"
+  depends_on "boost@1.69"
   depends_on "python"
 
   resource "numpy" do

--- a/boost@1.69.rb
+++ b/boost@1.69.rb
@@ -1,0 +1,104 @@
+class BoostAT169 < Formula
+  desc "Collection of portable C++ source libraries"
+  homepage "https://www.boost.org/"
+  url "https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2"
+  sha256 "8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406"
+  revision 2
+  head "https://github.com/boostorg/boost.git"
+
+  bottle do
+    cellar :any
+    sha256 "8089ad2fdc0edffcd0222043fda9a99bf82abf30f334305b9068fbef85b44893" => :mojave
+    sha256 "57b8e7c324620079499dfab19f894d7d2929d192f375ed9f09ebbff55c97f9f6" => :high_sierra
+    sha256 "98655462f9bf15f157f07fd27926d5adceb7fa3e966dd1ed5a096b68b8099474" => :sierra
+  end
+
+  depends_on "icu4c"
+
+  def install
+    # Force boost to compile with the desired compiler
+    open("user-config.jam", "a") do |file|
+      file.write "using darwin : : #{ENV.cxx} ;\n"
+    end
+
+    # libdir should be set by --prefix but isn't
+    icu4c_prefix = Formula["icu4c"].opt_prefix
+    bootstrap_args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-icu=#{icu4c_prefix}
+    ]
+
+    # Handle libraries that will not be built.
+    without_libraries = ["python", "mpi"]
+
+    # Boost.Log cannot be built using Apple GCC at the moment. Disabled
+    # on such systems.
+    without_libraries << "log" if ENV.compiler == :gcc
+
+    bootstrap_args << "--without-libraries=#{without_libraries.join(",")}"
+
+    # layout should be synchronized with boost-python and boost-mpi
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      -d2
+      -j#{ENV.make_jobs}
+      --layout=tagged-1.66
+      --user-config=user-config.jam
+      -sNO_LZMA=1
+      -sNO_ZSTD=1
+      install
+      threading=multi,single
+      link=shared,static
+    ]
+
+    # Boost is using "clang++ -x c" to select C compiler which breaks C++14
+    # handling using ENV.cxx14. Using "cxxflags" and "linkflags" still works.
+    args << "cxxflags=-std=c++14"
+    if ENV.compiler == :clang
+      args << "cxxflags=-stdlib=libc++" << "linkflags=-stdlib=libc++"
+    end
+
+    system "./bootstrap.sh", *bootstrap_args
+    system "./b2", "headers"
+    system "./b2", *args
+  end
+
+  def caveats
+    s = ""
+    # ENV.compiler doesn't exist in caveats. Check library availability
+    # instead.
+    if Dir["#{lib}/libboost_log*"].empty?
+      s += <<~EOS
+        Building of Boost.Log is disabled because it requires newer GCC or Clang.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <boost/algorithm/string.hpp>
+      #include <string>
+      #include <vector>
+      #include <assert.h>
+      using namespace boost::algorithm;
+      using namespace std;
+
+      int main()
+      {
+        string str("a,b");
+        vector<string> strVec;
+        split(strVec, str, is_any_of(","));
+        assert(strVec.size()==2);
+        assert(strVec[0]=="a");
+        assert(strVec[1]=="b");
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++14", "-stdlib=libc++", "-o", "test"
+    system "./test"
+  end
+end

--- a/boost@1.69.rb
+++ b/boost@1.69.rb
@@ -8,9 +8,8 @@ class BoostAT169 < Formula
 
   bottle do
     cellar :any
-    sha256 "8089ad2fdc0edffcd0222043fda9a99bf82abf30f334305b9068fbef85b44893" => :mojave
-    sha256 "57b8e7c324620079499dfab19f894d7d2929d192f375ed9f09ebbff55c97f9f6" => :high_sierra
-    sha256 "98655462f9bf15f157f07fd27926d5adceb7fa3e966dd1ed5a096b68b8099474" => :sierra
+    root_url "https://github.com/fiedl/homebrew-icecube/releases/download/boost-1.69.0_2/"
+    sha256 "bef69060e15160aee3aad8b875204bb14af0f8d3e09bb16d08866c8a0c2e502f" => :mojave
   end
 
   depends_on "icu4c"


### PR DESCRIPTION
### Why?

The current release V06-01-01 of icecube-simulation does not compile for me with boost 1.70 on mac-os mojave, which is the current default version when installing via `brew install boost`. 
https://github.com/Homebrew/homebrew-core/commits/master/Formula/boost.rb

icecube-simulation-V06-01-01 does work with boost version 1.69. But there is no out-of-the-box formula to install boost with version 1.69 provided by homebrew-core.

### How?

I've extracted the previous formula using `brew extract`:

```
[2019-08-28 18:09:01] fiedl@fiedl-mbp ~
▶ brew extract boost --version 1.69 fiedl/homebrew-icecube
▶ brew extract boost-python3 --version 1.69 fiedl/homebrew-icecube
```

In the `boost-python3@1.69.rb` file, I needed to modify the `boost` dependency to match the correct version.

I've also created bottles for mojave, which are used by default by the formulae provided in this pull request.
https://github.com/fiedl/homebrew-icecube/releases/tag/boost-1.69.0_2

### Tests

I've tested this install locally as well as using an automated build with github actions:
https://github.com/fiedl/hole-ice-install/commit/80348e728980b627a85718e4749f99f60552c89c/checks#step:3:11008